### PR TITLE
fix: removes unnecessary int conversion

### DIFF
--- a/bringing_a_gun_to_a_guard_fight.py
+++ b/bringing_a_gun_to_a_guard_fight.py
@@ -26,12 +26,10 @@ class Room:
         return angle
 
     def get_first_quadrant(self):
-        """gets the number of copies that need to be done along the axis
+        """Gets the number of copies that need to be done along the axis
         and gets all the guard and player coords"""
         num_copies_x = ceil(self.max_x / self.room_x)
-        num_copies_x = int(num_copies_x)
         num_copies_y = ceil(self.max_y / self.room_y)
-        num_copies_y = int(num_copies_y)
 
         player_exp_x = []
         player_exp_y = []


### PR DESCRIPTION
When using `ceil`, the result is already an integer, so performing an additional typecast to `int` will never change the value of `num_copies_x` or `num_copies_y`.